### PR TITLE
Update to v0.4.9.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Receive traffic on the Tor network and pass it along
 
 [![Automatic tests level](https://apps.yunohost.org/badge/cilevel/torrelay)](https://ci-apps.yunohost.org/ci/apps/torrelay/)
 
-🛠️ Upstream Tor relay repository: <https://github.com/torproject/tor>
+🛠️ Upstream Tor relay repository: <https://gitlab.torproject.org/tpo/core/tor>
 
 Pull request are welcome and should target the [`testing` branch](https://github.com/YunoHost-Apps/torrelay_ynh/tree/testing).
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Tor relay"
 description.en = "Receive traffic on the Tor network and pass it along"
 description.fr = "Recevez le trafic sur le réseau Tor et transmettez-le"
 
-version = "0.4.8.17~ynh2"
+version = "0.4.9.11~ynh1"
 
 maintainers = []
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -15,7 +15,7 @@ maintainers = []
 license = "BSD-3-Clause"
 website = "https://www.torproject.org/"
 admindoc = "https://community.torproject.org/relay/setup/bridge/debian-ubuntu/"
-code = "https://github.com/torproject/tor"
+code = "https://gitlab.torproject.org/tpo/core/tor"
 
 [integration]
 yunohost = ">= 12.1.17"


### PR DESCRIPTION
## Problem

- *v0.4.8.17 is obsolete*
https://forum.yunohost.org/t/tor-relay-update/42851
https://packages.debian.org/bookworm/tor

## Solution

- *Update to v0.4.9.11*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
